### PR TITLE
Fix #36  don't run out of sockets

### DIFF
--- a/match.go
+++ b/match.go
@@ -129,8 +129,9 @@ func (m *Match) PlayGame(g *Game) {
 		for result := range playerResultsCHAN {
 
 			// append game to player here since it's serialised across goroutines
-			// (avoids need for mutex)
+			result.player.mu.Lock()
 			result.player.Games = append(result.player.Games, result.state)
+			result.player.mu.Unlock()
 
 			// then perform all calculations across all the players for this particular game
 			if result.state.TotalTime < fastestTime {

--- a/player.go
+++ b/player.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,8 @@ type Player struct {
 	FailedToFinish bool `json:"failed_to_finish,omitempty"`
 
 	connection *PlayerConnection
+
+	mu sync.Mutex
 }
 
 type PlayerSummary struct {


### PR DESCRIPTION
reduced max concurrent requests to each client to avoid running out of sockets, and tidied up race conditions preventing users from maxing out their machines