### PR TITLE
fix #75: cleaner logic in result check, much more confident

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -14,28 +14,36 @@ func ValidGuess(guess, answer string) bool {
 func GetResult(guess, answer string) GuessResult {
 
 	result := make([]int, len(answer))
+	guessRunes := []rune(guess)
+	answerRunes := []rune(answer)
 
-	// I think there's probably an optimisation i could do here if
-	// i spent more time on leetcode.
-	for answerPos, answerChar := range answer {
-		bestPos := -1
-		bestResult := 0
-		for guessPos, guessChar := range guess {
-			if guessChar == answerChar && guessPos == answerPos {
-				bestPos = guessPos
-				bestResult = 2
-				break
-			}
-
-			if (bestPos == -1 || result[bestPos] > 0) && guessChar == answerChar {
-				bestPos = guessPos
-				bestResult = 1
-			}
+	// get greens
+	for i, guessRune := range guessRunes {
+		if guessRune != answerRunes[i] {
+			continue
 		}
 
-		if bestPos >= 0 {
-			result[bestPos] = bestResult
+		// benchmarked, it's much quicker to replace the rune than try and remove it any other way
+		answerRunes[i] = '😒'
+		result[i] = 2
+	}
+
+	// get yellows
+	for i, guessRune := range guessRunes {
+		if result[i] == 2 {
+			continue
 		}
+
+		for j, answerRune := range answerRunes {
+			if guessRune != answerRune {
+				continue
+			}
+			answerRunes[j] = '😒'
+			result[i] = 1
+			break
+
+		}
+
 	}
 
 	return GuessResult{

--- a/validation_test.go
+++ b/validation_test.go
@@ -29,6 +29,9 @@ var (
 		{"seers", "ulcer", []int{0, 1, 0, 1, 0}},
 		{"seers", "ulcee", []int{0, 1, 1, 0, 0}},
 		{"seerse", "elceec", []int{0, 1, 1, 0, 0, 1}},
+		{"golly", "bosom", []int{0, 2, 0, 0, 0}},
+		{"bosom", "golly", []int{0, 2, 0, 0, 0}},
+		{"bisom", "golly", []int{0, 0, 0, 1, 0}},
 	}
 )
 


### PR DESCRIPTION
Now making changes to the answer slice directly, and doing green check by itself first. Much more confident now. It also actually benchmarks faster now too.

Note, the cast from string to []rune actually takes 30% of the time. May be worth exploring eliminating this in the future, although it seems like the cast will still end up occurring somewhere. 